### PR TITLE
Changed to select

### DIFF
--- a/lib/mail/network/retriever_methods/imap.rb
+++ b/lib/mail/network/retriever_methods/imap.rb
@@ -121,7 +121,7 @@ module Mail
       mailbox = Net::IMAP.encode_utf7(mailbox)
 
       start do |imap|
-        imap.examine(mailbox)
+        imap.select(mailbox)
         imap.uid_search(['ALL']).each do |uid|
           imap.uid_store(uid, "+FLAGS", [Net::IMAP::DELETED])
         end


### PR DESCRIPTION
Net::IMAP#examine is select mail box with read-only attributes, so we could not delete mails in the box.
To delete mails, changed to Net::IMAP#select.