### PR TITLE
bug fix IMAP#delete_all

### DIFF
--- a/lib/mail/network/retriever_methods/imap.rb
+++ b/lib/mail/network/retriever_methods/imap.rb
@@ -116,6 +116,7 @@ module Mail
       mailbox = Net::IMAP.encode_utf7(mailbox)
 
       start do |imap|
+        imap.select(mailbox)
         imap.uid_search(['ALL']).each do |uid|
           imap.uid_store(uid, "+FLAGS", [Net::IMAP::DELETED])
         end


### PR DESCRIPTION
v2.6.6からブランチを切っています。

delete_allした際にmailboxがselectされておらず削除できないのでパッチを当てています。

https://github.com/mikel/mail/pull/1206
このPRがマージされるまで。